### PR TITLE
For a 0.3.0 release

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,4 +3,6 @@ coverage:
     project:
       default:
         threshold: 0.5%
-        target: auto
+    patch:
+      default:
+        target: 80%

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          MLFLOW_URI: "http://localhost:5000"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
@@ -12,4 +28,6 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 [compat]
 MLFlowClient = "0.4.4"
 MLJBase = "1.0.1"
-MLJModelInterface = "1.9.2"
+MLJModelInterface = "1.9.3"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJFlow"
 uuid = "7b7b8358-b45c-48ea-a8ef-7ca328ad328f"
 authors = ["Jose Esparza <joseesparzadc@icloud.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 MLFlowClient = "64a0f543-368b-4a9a-827a-e71edb2a0b83"

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 
 [compat]
 MLFlowClient = "0.4.4"
-MLJBase = "1"
-MLJModelInterface = "1.9.1"
+MLJBase = "1.0.1"
+MLJModelInterface = "1.9.2"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The entire workload is divided into three different repositories:
 - [x] MLflow cycle automation (create experiment, create run, log metrics, log parameters,
       log artifacts, etc.)
 
-- [x] Provides a wrapper `MLFlowLogger` for MLFlowClient.jl clients and associated
+- [x] Provides a wrapper `Logger` for MLFlowClient.jl clients and associated
       metadata; instances of this type are valid "loggers", which can be passed to MLJ
       functions supporting the `logger` keyword argument.
 	  
@@ -71,7 +71,7 @@ We first define a logger, providing the address of our running MLflow. The exper
 name and artifact location are optional.
 
 ```julia
-logger = MLFlowLogger(
+logger = MLJFlow.Logger(
     "http://127.0.0.1:5000";
     experiment_name="MLJFlow test",
     artifact_location="./mlj-test"

--- a/src/MLJFlow.jl
+++ b/src/MLJFlow.jl
@@ -12,7 +12,4 @@ include("types.jl")
 include("base.jl")
 include("service.jl")
 
-# types.jl
-export MLFlowLogger
-
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,4 +1,4 @@
-function log_evaluation(logger::MLFlowLogger, performance_evaluation)
+function log_evaluation(logger, performance_evaluation)
     experiment = getorcreateexperiment(logger.service, logger.experiment_name;
         artifact_location=logger.artifact_location)
     run = createrun(logger.service, experiment;
@@ -19,12 +19,12 @@ function log_evaluation(logger::MLFlowLogger, performance_evaluation)
     updaterun(logger.service, run, "FINISHED")
 end
 
-function save(logger::MLFlowLogger, mach::Machine)
+function save(logger, machine:: Machine)
     io = IOBuffer()
-    save(io, mach)
+    save(io, machine)
     seekstart(io)
 
-    model = mach.model
+    model = machine.model
 
     experiment = getorcreateexperiment(logger.service, logger.experiment_name;
         artifact_location=logger.artifact_location)

--- a/src/service.jl
+++ b/src/service.jl
@@ -75,8 +75,8 @@ function logmachinemeasures(service::MLFlow, run::MLFlowRun, measures,
 end
 
 """
-    service(logger::MLFlowLogger)
+    service(logger)
 
 Returns the MLFlow service of a logger.
 """
-service(logger::MLFlowLogger) = logger.service
+service(logger) = logger.service

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,5 @@
 """
-    MLFlowLogger(baseuri; experiment_name="MLJ experiment",
+    Logger(baseuri; experiment_name="MLJ experiment",
         artifact_location=nothing)
 
 A wrapper around a MLFlow service, with an experiment name and an artifact
@@ -17,24 +17,24 @@ used to store the artifacts of the experiment. If not provided, a default
 artifact location will be defined by MLFlow. For more information, see
 [MLFlow documentation](https://www.mlflow.org/docs/latest/tracking.html).
 
-This constructor returns a `MLFlowLogger` object, containing the experiment
+This constructor returns a `Logger` object, containing the experiment
 name and the artifact location specified previously. Also it contains a
 `MLFlow` service, which is used to communicate with the MLFlow server. For
 more information, see [MLFlowClient.jl](https://juliaai.github.io/MLFlowClient.jl/dev/reference/#MLFlowClient.MLFlow).
 
 """
-struct MLFlowLogger
+struct Logger
     service::MLFlow
     verbosity::Int
     experiment_name::String
     artifact_location::Union{String,Nothing}
 end
-function MLFlowLogger(baseuri; experiment_name="MLJ experiment",
+function Logger(baseuri; experiment_name="MLJ experiment",
     artifact_location=nothing, verbosity=1)
     service = MLFlow(baseuri)
 
     if ~healthcheck(service)
         error("It seems that the MLFlow server is not running. For more information, see https://mlflow.org/docs/latest/quickstart.html")
     end
-    MLFlowLogger(service, verbosity, experiment_name, artifact_location)
+    Logger(service, verbosity, experiment_name, artifact_location)
 end

--- a/test/base.jl
+++ b/test/base.jl
@@ -1,5 +1,5 @@
 @testset verbose = true "base" begin
-    logger = MLFlowLogger("http://localhost:5000";
+    logger = MLJFlow.Logger("http://localhost:5000";
         experiment_name="MLJFlow tests",
         artifact_location="/tmp/mlj-test")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,16 @@ using MLFlowClient
 using MLJModelInterface
 using StatisticalMeasures
 
+# To run this tests, you need to set the URI of your MLFlow server. By default,
+# you can set:
+#
+# ENV["MLFLOW_URI"] = "http://localhost:5000"
+#
+# For more information, see https://mlflow.org/docs/latest/quickstart.html#view-mlflow-runs-and-experiments
+if ~haskey(ENV, "MLFLOW_URI")
+    error("WARNING: MLFLOW_URI is not set. To run this tests, you need to set the URI of your MLFlow server")
+end
+
 include("base.jl")
 include("types.jl")
 include("service.jl")

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,6 +1,6 @@
 @testset "types" begin
-    logger = MLFlowLogger("http://localhost:5000")
+    logger = MLJFlow.Logger("http://localhost:5000")
 
-    @test typeof(logger) == MLFlowLogger
+    @test typeof(logger) == MLJFlow.Logger
     @test typeof(logger.service) == MLFlow
 end


### PR DESCRIPTION
#23 #20 #30 

(**breaking**) An MLFlowLogger (exported) is now renamed to Logger (unexported). So a logger instance is now instantiated with `using MLJFlow; logger = MLJFlow.Logger(baseuri)`.


I've update the TagBot config file and played around with workflow settings. So hopefully we'll get a new release tag this time.